### PR TITLE
fix: safe lift env gets world offset

### DIFF
--- a/crax/envs/safe_lift.py
+++ b/crax/envs/safe_lift.py
@@ -286,7 +286,7 @@ class SafeLift(PipelineEnv, ABC):
             local_offset = self._foot_local_offsets[foot_key]
 
             # Transform local offset to world coordinates
-            world_offset = math.rotate(body_rot, local_offset)
+            world_offset = math.rotate(local_offset, body_rot)
             foot_world_z = body_pos[2] + world_offset[2]
             foot_z_positions.append(foot_world_z)
 


### PR DESCRIPTION
Fix the shape error when training safe lift: 

The log of the original code:

> /home/moss_ubuntu/workspace/CRAX/crax/io/mjcf.py:40: RuntimeWarning: Falling back to mujoco.mjx (no Brax collision patches): cannot import name '_resolve_impl_and_device' from 'mujoco.mjx._src.io' (/home/moss_ubuntu/workspace/CRAX/.venv/lib/python3.10/site-packages/mujoco/mjx/_src/io.py)
  warnings.warn(
Checking that the installation succeeded:
Installation successful.
==================================================
Running experiment with seed 0
==================================================
/home/moss_ubuntu/workspace/CRAX/crax/io/mjcf.py:487: UserWarning: Brax System, piplines and environments are not actively being maintained. Please see MJX for a well maintained JAX-based physics engine: https://github.com/google-deepmind/mujoco/tree/main/mjx. For a host of environments that use MJX, see: https://github.com/google-deepmind/mujoco_playground.
  warnings.warn(
Training environment 'safe_lift_ant' instantiated with difficulty 1.
Evaluation environment 'safe_lift_ant' instantiated with difficulty 1.
[DEBUG] train_kwargs keys: ['max_devices_per_host', 'num_timesteps', 'episode_length', 'num_envs', 'unroll_length', 'batch_size', 'num_minibatches', 'num_updates_per_batch', 'learning_rate', 'entropy_cost', 'discounting', 'reward_scaling', 'gae_lambda', 'clipping_epsilon', 'normalize_observations', 'num_evals', 'num_eval_envs', 'deterministic_eval', 'training_metrics_steps', 'safety_bound', 'lagrangian_coef_rate', 'initial_lambda_lagr', 'seed', 'save_checkpoint_path']
[DEBUG] Calling train_fn for ppo_lag / safe_lift_ant...
[DEBUG ppo/train] train() called: num_envs=4, num_timesteps=128.0, episode_length=16, augment_pixels=False
[DEBUG ppo/train] Wrapping environment...
[DEBUG ppo/train] Environment wrapped. obs_size=27, action_size=8
[DEBUG ppo/train] Calling reset_fn (use_pmap=False, key_envs.shape=(1, 4, 2))... This triggers JIT + pixel rendering.
[DEBUG ppo/train] reset_fn completed in 4.3s
[DEBUG ppo/train] obs_shape after reset: (27,)
[DEBUG ppo/train] Creating PPO network (network_factory=network_factory)...
[DEBUG ppo/train] PPO network created. cost_value_network=yes
[DEBUG ppo/train] Initializing network params...
[DEBUG ppo/train] Network params initialized. policy keys: ['hidden_0', 'hidden_1', 'hidden_2', 'hidden_3', 'hidden_4']
[DEBUG ppo/train] Building obs_spec and TrainingState...
[DEBUG ppo/train] obs_spec: Array(shape=(27,), dtype=dtype('float32'))
[DEBUG ppo/train] obs_spec after _remove_pixels: Array(shape=(27,), dtype=dtype('float32'))
[DEBUG ppo/train] TrainingState created.
[DEBUG ppo/train] Replicating training state to devices...
[DEBUG ppo/train] Training state replicated.
[DEBUG ppo/train] Creating Evaluator (num_eval_envs=2)...
[DEBUG ppo/train] Evaluator created.
[DEBUG ppo/train] Entering main training loop: 1 iterations, 1 resets/eval, 8 steps/epoch
[DEBUG ppo/train] Starting training_epoch_with_timing (iter 0)... (includes JIT compile on first call)
jax.errors.SimplifiedTraceback: For simplicity, JAX has removed its internal frames from the traceback of the following exception. Set JAX_TRACEBACK_FILTERING=off to include these.
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/home/moss_ubuntu/workspace/CRAX/train_env.py", line 221, in <module>
    main()
  File "/home/moss_ubuntu/workspace/CRAX/train_env.py", line 135, in main
    make_inference_fn, params, final_metrics, eval_env = train_fn(
  File "/home/moss_ubuntu/workspace/CRAX/crax/training/agents/ppo_lag/train.py", line 175, in train
    return ppo_train.train(
  File "/home/moss_ubuntu/workspace/CRAX/crax/training/agents/ppo/train.py", line 818, in train
    training_epoch_with_timing(training_state, env_state, epoch_keys)
  File "/home/moss_ubuntu/workspace/CRAX/crax/training/agents/ppo/train.py", line 634, in training_epoch_with_timing
    result = training_epoch(training_state, env_state, key)
  File "/home/moss_ubuntu/workspace/CRAX/crax/training/agents/ppo/train.py", line 612, in training_epoch
    (training_state, state, _), loss_metrics = jax.lax.scan(
  File "/home/moss_ubuntu/workspace/CRAX/crax/training/agents/ppo/train.py", line 551, in training_step
    (state, _), data = jax.lax.scan(
  File "/home/moss_ubuntu/workspace/CRAX/crax/training/agents/ppo/train.py", line 541, in f
    next_state, data = acting.generate_unroll(
  File "/home/moss_ubuntu/workspace/CRAX/crax/training/acting.py", line 73, in generate_unroll
    (final_state, _), data = jax.lax.scan(
  File "/home/moss_ubuntu/workspace/CRAX/crax/training/acting.py", line 68, in f
    nstate, transition = actor_step(
  File "/home/moss_ubuntu/workspace/CRAX/crax/training/acting.py", line 42, in actor_step
    nstate = env.step(env_state, actions)
  File "/home/moss_ubuntu/workspace/CRAX/crax/envs/wrappers/training.py", line 143, in step
    state = self.env.step(state, action)
  File "/home/moss_ubuntu/workspace/CRAX/crax/envs/wrappers/training.py", line 102, in step
    state, rewards = jax.lax.scan(f, state, (), self.action_repeat)
  File "/home/moss_ubuntu/workspace/CRAX/crax/envs/wrappers/training.py", line 99, in f
    nstate = self.env.step(state, action)
  File "/home/moss_ubuntu/workspace/CRAX/crax/envs/wrappers/training.py", line 71, in step
    return jax.vmap(self.env.step)(state, action)
  File "/home/moss_ubuntu/workspace/CRAX/crax/envs/__init__.py", line 147, in step
    next_state = self.env.step(state, action)
  File "/home/moss_ubuntu/workspace/CRAX/crax/envs/safe_lift.py", line 244, in step
    cost = self._calculate_foot_contact_cost(pipeline_state)
  File "/home/moss_ubuntu/workspace/CRAX/crax/envs/safe_lift.py", line 325, in _calculate_foot_contact_cost
    foot_z_positions = self._get_foot_world_positions(pipeline_state)
  File "/home/moss_ubuntu/workspace/CRAX/crax/envs/safe_lift.py", line 289, in _get_foot_world_positions
    world_offset = math.rotate(body_rot, local_offset)
  File "/home/moss_ubuntu/workspace/CRAX/crax/math.py", line 38, in rotate
    r = 2 * (jp.dot(u, vec) * u) + (s * s - jp.dot(u, u)) * vec
  File "/home/moss_ubuntu/workspace/CRAX/.venv/lib/python3.10/site-packages/jax/_src/numpy/tensor_contractions.py", line 121, in dot
    result = lax.dot_general(a, b, dimension_numbers=(contract_dims, batch_dims),
TypeError: dot_general requires contracting dimensions to have the same shape, got (2,) and (4,).


After fix: 

> /home/moss_ubuntu/workspace/CRAX/crax/io/mjcf.py:40: RuntimeWarning: Falling back to mujoco.mjx (no Brax collision patches): cannot import name '_resolve_impl_and_device' from 'mujoco.mjx._src.io' (/home/moss_ubuntu/workspace/CRAX/.venv/lib/python3.10/site-packages/mujoco/mjx/_src/io.py)
  warnings.warn(
Checking that the installation succeeded:
Installation successful.
==================================================
Running experiment with seed 0
==================================================
/home/moss_ubuntu/workspace/CRAX/crax/io/mjcf.py:487: UserWarning: Brax System, piplines and environments are not actively being maintained. Please see MJX for a well maintained JAX-based physics engine: https://github.com/google-deepmind/mujoco/tree/main/mjx. For a host of environments that use MJX, see: https://github.com/google-deepmind/mujoco_playground.
  warnings.warn(
Training environment 'safe_lift_ant' instantiated with difficulty 1.
Evaluation environment 'safe_lift_ant' instantiated with difficulty 1.
[DEBUG] train_kwargs keys: ['max_devices_per_host', 'num_timesteps', 'episode_length', 'num_envs', 'unroll_length', 'batch_size', 'num_minibatches', 'num_updates_per_batch', 'learning_rate', 'entropy_cost', 'discounting', 'reward_scaling', 'gae_lambda', 'clipping_epsilon', 'normalize_observations', 'num_evals', 'num_eval_envs', 'deterministic_eval', 'training_metrics_steps', 'safety_bound', 'lagrangian_coef_rate', 'initial_lambda_lagr', 'seed']
[DEBUG] Calling train_fn for ppo_lag / safe_lift_ant...
[DEBUG ppo/train] train() called: num_envs=4, num_timesteps=128.0, episode_length=16, augment_pixels=False
[DEBUG ppo/train] Wrapping environment...
[DEBUG ppo/train] Environment wrapped. obs_size=27, action_size=8
[DEBUG ppo/train] Calling reset_fn (use_pmap=False, key_envs.shape=(1, 4, 2))... This triggers JIT + pixel rendering.
[DEBUG ppo/train] reset_fn completed in 4.2s
[DEBUG ppo/train] obs_shape after reset: (27,)
[DEBUG ppo/train] Creating PPO network (network_factory=network_factory)...
[DEBUG ppo/train] PPO network created. cost_value_network=yes
[DEBUG ppo/train] Initializing network params...
[DEBUG ppo/train] Network params initialized. policy keys: ['hidden_0', 'hidden_1', 'hidden_2', 'hidden_3', 'hidden_4']
[DEBUG ppo/train] Building obs_spec and TrainingState...
[DEBUG ppo/train] obs_spec: Array(shape=(27,), dtype=dtype('float32'))
[DEBUG ppo/train] obs_spec after _remove_pixels: Array(shape=(27,), dtype=dtype('float32'))
[DEBUG ppo/train] TrainingState created.
[DEBUG ppo/train] Replicating training state to devices...
[DEBUG ppo/train] Training state replicated.
[DEBUG ppo/train] Entering main training loop: 1 iterations, 1 resets/eval, 8 steps/epoch
[DEBUG ppo/train] Starting training_epoch_with_timing (iter 0)... (includes JIT compile on first call)
[DEBUG ppo/train] training_epoch_with_timing completed in 15.1s (iter 0)
Step 128:
  training/cost_v_loss: 0.011946611106395721
  training/cost_violation: -1.5625
  training/lambda_lagr: 0.0
  training/mean_cost: 0.0
Training finished.
All experiments completed!